### PR TITLE
Fixed inconsistent behaviour of readFile function. …

### DIFF
--- a/file_utils.js
+++ b/file_utils.js
@@ -49,6 +49,7 @@ const readFile = async (files) => {
   if (files.includes(',')) {
     const filesToIterate = files.split(',')
     return Promise.all(filesToIterate.map(file => asyncReadFile(`${folderPath}/${file}.gitignore`, { encoding: 'utf-8' })))
+      .then(filesContent => filesContent.join(''))
       .catch(e => console.error(e))
   }
 


### PR DESCRIPTION
Now readFile function will always return the strings instead of arrays.

Previously if we allow user to specify multiple languages `readFile` function used to return array since we used `Promise.all` which will add `,` while writing to `.gitignore` file.

With this change, `readFile` function will always returns the string instead of arrays which will remove automatic addition of `,` to the `.gitignore` file