### PR TITLE
fix: correct writefile bug when choosing multiple languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,5 +41,5 @@ const {
   const gitignoreContent = await readFile(`${file}`)
 
   // Create the .gitignore file
-  await writeFile('.gitignore', gitignoreContent)
+  await writeFile('.gitignore', gitignoreContent.toString())
 })();


### PR DESCRIPTION
This change corrects an error generated from selecting multiple languages, where it would pass an array into the writeFile command. Now all data passed to writeFile is converted into a string. This is a very small correction, where I just add `.toString()` to the data being passed to `writeFile()`

Error encountered
```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Array
    at writeFile (node:fs:2168:5)
    at node:internal/util:364:7
    at new Promise (<anonymous>)
    at writeFile (node:internal/util:350:12)
    at writeFile (/Users/alexyounger/.config/yarn/global/node_modules/gitignore-it/file_utils.js:37:9)
    at /Users/alexyounger/.config/yarn/global/node_modules/gitignore-it/index.js:44:9 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

Solution
```javascript
await writeFile('.gitignore', gitignoreContent.toString())
```